### PR TITLE
Build project code

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -280,15 +280,15 @@ dependencies {
     appcenterdebugImplementation leakCanary
     debugImplementation leakCanary
 
-    // Wallet kits
-    implementation 'com.github.horizontalsystems:ton-kit-android:763a5c3'
-    implementation 'com.github.horizontalsystems:bitcoin-kit-android:ced5801'
-    implementation 'com.github.horizontalsystems:ethereum-kit-android:0c770e3'
-    implementation 'com.github.horizontalsystems:blockchain-fee-rate-kit-android:1d3bd49'
-    implementation 'com.github.horizontalsystems:binance-chain-kit-android:c1509a2'
-    implementation 'com.github.horizontalsystems:market-kit-android:4201f8f'
-    implementation 'com.github.horizontalsystems:solana-kit-android:ce738d8'
-    implementation 'com.github.horizontalsystems:tron-kit-android:dc3dca7'
+    // Wallet kits - using master branches as fallback
+    implementation 'com.github.horizontalsystems:ton-kit-android:master'
+    implementation 'com.github.horizontalsystems:bitcoin-kit-android:master'
+    implementation 'com.github.horizontalsystems:ethereum-kit-android:master'
+    implementation 'com.github.horizontalsystems:blockchain-fee-rate-kit-android:master'
+    implementation 'com.github.horizontalsystems:binance-chain-kit-android:master'
+    implementation 'com.github.horizontalsystems:market-kit-android:master'
+    implementation 'com.github.horizontalsystems:solana-kit-android:master'
+    implementation 'com.github.horizontalsystems:tron-kit-android:master'
     // Zcash SDK
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.4'
     implementation "cash.z.ecc.android:zcash-android-sdk:2.2.6"


### PR DESCRIPTION
Update JitPack wallet kit dependencies to use `master` branches to resolve 404 errors with specific commit hashes.

The original build failed because several wallet kit dependencies, specified by exact commit hashes on JitPack, were returning 404 errors, indicating they were no longer available. This PR updates these dependencies to use their respective `master` branches as a fallback to allow the project to build.

---
<a href="https://cursor.com/background-agent?bcId=bc-cc586b3b-df22-48bb-be95-516c0a3c3761"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cc586b3b-df22-48bb-be95-516c0a3c3761"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

